### PR TITLE
Restrict ng-deep selector to json-schema-form

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "angular6-json-schema-form",
+  "name": "angular6-json-schema-form-app",
   "version": "1.0.3",
   "author": "https://github.com/hamzahamidi/Angular6-json-schema-form/graphs/contributors",
   "description": "Angular JSON Schema Form builder Demo",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "angular6-json-schema-form-app",
+  "name": "angular6-json-schema-form",
   "version": "1.0.3",
   "author": "https://github.com/hamzahamidi/Angular6-json-schema-form/graphs/contributors",
   "description": "Angular JSON Schema Form builder Demo",

--- a/projects/angular6-json-schema-form/src/lib/framework-library/material-design-framework/material-datepicker.component.ts
+++ b/projects/angular6-json-schema-form/src/lib/framework-library/material-design-framework/material-datepicker.component.ts
@@ -53,7 +53,7 @@ import { dateToString, stringToDate } from '../../shared';
       [innerHTML]="options?.errorMessage"></mat-error>`,
   styles: [`
     mat-error { font-size: 75%; margin-top: -1rem; margin-bottom: 0.5rem; }
-    ::ng-deep mat-form-field .mat-form-field-wrapper .mat-form-field-flex
+    ::ng-deep json-schema-form mat-form-field .mat-form-field-wrapper .mat-form-field-flex
       .mat-form-field-infix { width: initial; }
   `],
 })

--- a/projects/angular6-json-schema-form/src/lib/framework-library/material-design-framework/material-input.component.ts
+++ b/projects/angular6-json-schema-form/src/lib/framework-library/material-design-framework/material-input.component.ts
@@ -57,7 +57,7 @@ import { JsonSchemaFormService } from '../../json-schema-form.service';
       [innerHTML]="options?.errorMessage"></mat-error>`,
   styles: [`
     mat-error { font-size: 75%; margin-top: -1rem; margin-bottom: 0.5rem; }
-    ::ng-deep mat-form-field .mat-form-field-wrapper .mat-form-field-flex
+    ::ng-deep json-schema-form mat-form-field .mat-form-field-wrapper .mat-form-field-flex
       .mat-form-field-infix { width: initial; }
   `],
 })

--- a/projects/angular6-json-schema-form/src/lib/framework-library/material-design-framework/material-number.component.ts
+++ b/projects/angular6-json-schema-form/src/lib/framework-library/material-design-framework/material-number.component.ts
@@ -53,7 +53,7 @@ import { JsonSchemaFormService } from '../../json-schema-form.service';
       [innerHTML]="options?.errorMessage"></mat-error>`,
   styles: [`
     mat-error { font-size: 75%; margin-top: -1rem; margin-bottom: 0.5rem; }
-    ::ng-deep mat-form-field .mat-form-field-wrapper .mat-form-field-flex
+    ::ng-deep json-schema-form mat-form-field .mat-form-field-wrapper .mat-form-field-flex
       .mat-form-field-infix { width: initial; }
   `],
 })

--- a/projects/angular6-json-schema-form/src/lib/framework-library/material-design-framework/material-select.component.ts
+++ b/projects/angular6-json-schema-form/src/lib/framework-library/material-design-framework/material-select.component.ts
@@ -74,7 +74,7 @@ import { JsonSchemaFormService } from '../../json-schema-form.service';
       [innerHTML]="options?.errorMessage"></mat-error>`,
   styles: [`
     mat-error { font-size: 75%; margin-top: -1rem; margin-bottom: 0.5rem; }
-    ::ng-deep mat-form-field .mat-form-field-wrapper .mat-form-field-flex
+    ::ng-deep json-schema-form mat-form-field .mat-form-field-wrapper .mat-form-field-flex
       .mat-form-field-infix { width: initial; }
   `],
 })

--- a/projects/angular6-json-schema-form/src/lib/framework-library/material-design-framework/material-textarea.component.ts
+++ b/projects/angular6-json-schema-form/src/lib/framework-library/material-design-framework/material-textarea.component.ts
@@ -51,7 +51,7 @@ import { JsonSchemaFormService } from '../../json-schema-form.service';
       [innerHTML]="options?.errorMessage"></mat-error>`,
   styles: [`
     mat-error { font-size: 75%; margin-top: -1rem; margin-bottom: 0.5rem; }
-    ::ng-deep mat-form-field .mat-form-field-wrapper .mat-form-field-flex
+    ::ng-deep json-schema-form mat-form-field .mat-form-field-wrapper .mat-form-field-flex
       .mat-form-field-infix { width: initial; }
   `],
 })


### PR DESCRIPTION
- ng-deep selector bleeds up the stack into parent components
- avoid this by restricting the selector to json-schema-form
- Note - ng-deep is now deprecated (see https://angular.io/guide/component-styles#deprecated-deep--and-ng-deep)