### PR TITLE
Fixed $comment issue in merge-schemas

### DIFF
--- a/projects/angular6-json-schema-form/src/lib/shared/merge-schemas.function.ts
+++ b/projects/angular6-json-schema-form/src/lib/shared/merge-schemas.function.ts
@@ -298,7 +298,7 @@ export function mergeSchemas(...schemas) {
           case '$schema': case '$id': case 'id':
             // Don't combine these keys
           break;
-          case 'title': case 'description':
+          case 'title': case 'description': case '$comment':
             // Return the last value, overwriting any previous one
             // These properties are not used for validation, so conflicts don't matter
             combinedSchema[key] = schemaValue;


### PR DESCRIPTION
Now the parser properly knows to use the latest value instead of returning allof structure because it doesn't know how to combine the schemas (encountered this with a $ref definition had a comment and so did the outer referring object)