### PR TITLE
use ngClass instead of class

### DIFF
--- a/projects/angular6-json-schema-form/src/lib/framework-library/material-design-framework/flex-layout-section.component.ts
+++ b/projects/angular6-json-schema-form/src/lib/framework-library/material-design-framework/flex-layout-section.component.ts
@@ -66,7 +66,7 @@ import { JsonSchemaFormService } from '../../json-schema-form.service';
     </fieldset>
 
     <mat-card *ngIf="containerType === 'card'"
-      [class]="options?.htmlClass || ''"
+      [ngClass]="options?.htmlClass || ''"
       [class.expandable]="options?.expandable && !expanded"
       [class.expanded]="options?.expandable && expanded">
       <mat-card-header *ngIf="sectionTitle">


### PR DESCRIPTION
Fix for Issue #51 

Using `[ngClass]` instead of `class` allows both angular material and AJSF to set classes on the `mat-card`.
 