### PR TITLE
Condition == evaluation fix

### DIFF
--- a/projects/angular6-json-schema-form/src/lib/shared/jspointer.functions.json.spec.ts
+++ b/projects/angular6-json-schema-form/src/lib/shared/jspointer.functions.json.spec.ts
@@ -1,0 +1,103 @@
+import {JsonPointer} from './jsonpointer.functions';
+
+const subObjectWithEvaluatedProperty = {name: 'abc', other_property: false};
+
+describe('JsonPointer.evaluateExpression', () => {
+
+  it('should return true when subObject and corresponding key is given', () => {
+    const result = JsonPointer.evaluateExpression({name: 'abc', other_property: false}, 'name==\'abc\'');
+
+    expect(result.passed).toEqual(true);
+  });
+
+  it('should not fail when subObject is null', () => {
+    const result = JsonPointer.evaluateExpression(null, 'name==\'abc\'');
+
+    expect(result).toBeDefined();
+  });
+
+  it('should not fail when subObject is undefined', () => {
+    const result = JsonPointer.evaluateExpression(undefined, 'name==\'abc\'');
+
+    expect(result).toBeDefined();
+  });
+
+  it('should return false when key is undefined', () => {
+    const result = JsonPointer.evaluateExpression(subObjectWithEvaluatedProperty, undefined);
+
+    expect(result.passed).toBeFalsy();
+  });
+
+  it('should return false when key is null', () => {
+    const result = JsonPointer.evaluateExpression(subObjectWithEvaluatedProperty, null);
+
+    expect(result.passed).toBeFalsy();
+  });
+
+  it('should return false when key corrupted', () => {
+    const result = JsonPointer.evaluateExpression(subObjectWithEvaluatedProperty, 'name=\'abc\'');
+
+    expect(result.passed).toBeFalsy();
+  });
+
+  it('should return the same key when key corrupted', () => {
+    const key = 'name=\'abc\'';
+    const result = JsonPointer.evaluateExpression(subObjectWithEvaluatedProperty, key);
+
+    expect(result.key).toEqual(key);
+  });
+
+  it('should return the first part of key when key contains equals', () => {
+    const result = JsonPointer.evaluateExpression(subObjectWithEvaluatedProperty, 'name==\'abc\'');
+
+    expect(result.key).toEqual('name');
+  });
+
+  it('should not return the first part of key when key contains not equals', () => {
+    const result = JsonPointer.evaluateExpression(subObjectWithEvaluatedProperty, 'name!=\'abc\'');
+
+    expect(result.key).not.toEqual('name');
+  });
+
+  it('should return false when key equals does not correspond to the subObject property', () => {
+    const result = JsonPointer.evaluateExpression(subObjectWithEvaluatedProperty, 'somethingElse==\'abc\'');
+
+    expect(result.passed).toBeFalsy();
+  });
+
+  it('should return true when key not equals does not correspond to the subObject property', () => {
+    const result = JsonPointer.evaluateExpression(subObjectWithEvaluatedProperty, 'somethingElse!=\'abc\'');
+
+    expect(result.passed).toBeTruthy();
+  });
+
+  it('should return the first part of key when key does not equal to the property value', () => {
+    const result = JsonPointer.evaluateExpression(subObjectWithEvaluatedProperty, 'name!=\'cba\'');
+
+    expect(result.key).toEqual('name');
+  });
+
+  it('should return the first part of key when key does equal to the property value', () => {
+    const result = JsonPointer.evaluateExpression(subObjectWithEvaluatedProperty, 'name==\'abc\'');
+
+    expect(result.key).toEqual('name');
+  });
+
+  it('should return false when key is different', () => {
+    const result = JsonPointer.evaluateExpression(subObjectWithEvaluatedProperty, 'eman==\'abc\'');
+
+    expect(result.passed).toBeFalsy();
+  });
+
+  it('should return true when key is without quotes', () => {
+    const result = JsonPointer.evaluateExpression({name: 'abc', other_property: false}, 'name==abc');
+
+    expect(result.passed).toEqual(true);
+  });
+
+  it('should return false when key has different value', () => {
+    const result = JsonPointer.evaluateExpression(subObjectWithEvaluatedProperty, 'name==\'cba\'');
+
+    expect(result.passed).toBeFalsy();
+  });
+});

--- a/projects/angular6-json-schema-form/src/lib/shared/utility.functions.ts
+++ b/projects/angular6-json-schema-form/src/lib/shared/utility.functions.ts
@@ -1,15 +1,4 @@
-import {
-  hasValue,
-  inArray,
-  isArray,
-  isDefined,
-  isEmpty,
-  isMap,
-  isObject,
-  isSet,
-  isString,
-  PlainObject
-  } from './validator.functions';
+import {hasValue, inArray, isArray, isDefined, isEmpty, isMap, isObject, isSet, isString, PlainObject} from './validator.functions';
 
 /**
  * Utility function library:
@@ -174,6 +163,70 @@ export function hasOwn(object: any, property: string): boolean {
     property = property + '';
   }
   return object.hasOwnProperty(property);
+}
+
+/**
+ * Types of possible expressions which the app is able to evaluate.
+ */
+export enum ExpressionType {
+  EQUALS,
+  NOT_EQUALS,
+  NOT_AN_EXPRESSION
+}
+
+/**
+ * Detects the type of expression from the given candidate. `==` for equals,
+ * `!=` for not equals. If none of these are contained in the candidate, the candidate
+ * is not considered to be an expression at all and thus `NOT_AN_EXPRESSION` is returned.
+ * // {expressionCandidate} expressionCandidate - potential expression
+ */
+export function getExpressionType(expressionCandidate: string): ExpressionType {
+  if (expressionCandidate.indexOf('==') !== -1) {
+    return ExpressionType.EQUALS;
+  }
+
+  if (expressionCandidate.toString().indexOf('!=') !== -1) {
+    return ExpressionType.NOT_EQUALS;
+  }
+
+  return ExpressionType.NOT_AN_EXPRESSION;
+}
+
+export function isEqual(expressionType) {
+  return expressionType as ExpressionType === ExpressionType.EQUALS;
+}
+
+export function isNotEqual(expressionType) {
+  return expressionType as ExpressionType === ExpressionType.NOT_EQUALS;
+}
+
+export function isNotExpression(expressionType) {
+  return expressionType as ExpressionType === ExpressionType.NOT_AN_EXPRESSION;
+}
+
+/**
+ * Splits the expression key by the expressionType on a pair of values
+ * before and after the equals or nor equals sign.
+ * // {expressionType} enum of an expression type
+ * // {key} the given key from a for loop iver all conditions
+ */
+export function getKeyAndValueByExpressionType(expressionType: ExpressionType, key: string) {
+  if (isEqual(expressionType)) {
+    return key.split('==', 2);
+  }
+
+  if (isNotEqual(expressionType)) {
+    return key.split('!=', 2);
+  }
+
+  return null;
+}
+
+export function cleanValueOfQuotes(keyAndValue): String {
+  if (keyAndValue.charAt(0) === '\'' && keyAndValue.charAt(keyAndValue.length - 1) === '\'') {
+    return keyAndValue.replace('\'', '').replace('\'', '');
+  }
+  return keyAndValue;
 }
 
 /**


### PR DESCRIPTION
Added missing condition `== ` evaluation for text expressions.
For example, the layout section can now contain the condition
as follows:

`
"condition": "model.name=='abc'"
`

In order to show certain property base on the name property value.

Fixes: `Condition with == does not work #98` [https://github.com/hamzahamidi/Angular6-json-schema-form/issues/98]