### PR TITLE
Fix drag drop in Firefox

### DIFF
--- a/projects/angular6-json-schema-form/src/lib/widget-library/orderable.directive.ts
+++ b/projects/angular6-json-schema-form/src/lib/widget-library/orderable.directive.ts
@@ -61,6 +61,7 @@ export class OrderableDirective implements OnInit {
 
         this.element.addEventListener('dragstart', (event) => {
           event.dataTransfer.effectAllowed = 'move';
+          event.dataTransfer.setData('text', '');
           // Hack to bypass stupid HTML drag-and-drop dataTransfer protection
           // so drag source info will be available on dragenter
           const sourceArrayIndex = this.dataIndex[this.dataIndex.length - 1];


### PR DESCRIPTION
Drag & drop doesn't work in Firefox, this fixes it.

It might be smart to change to https://material.angular.io/cdk/drag-drop/overview instead of maintaining a separate drag&drop functionality?