### PR TITLE
Add form autocomplete

### DIFF
--- a/projects/angular6-json-schema-form/src/lib/json-schema-form.component.ts
+++ b/projects/angular6-json-schema-form/src/lib/json-schema-form.component.ts
@@ -79,7 +79,7 @@ export const JSON_SCHEMA_FORM_VALUE_ACCESSOR: any = {
     <div *ngFor="let script of scripts">
       <script type="text/javascript" [src]="script"></script>
     </div>
-    <form class="json-schema-form" (ngSubmit)="submitForm()">
+    <form [autocomplete]="jsf?.formOptions?.autocomplete ? 'on' : 'off'" class="json-schema-form" (ngSubmit)="submitForm()">
       <root-widget [layout]="jsf?.layout"></root-widget>
     </form>
     <div *ngIf="debug || jsf?.formOptions?.debug">

--- a/projects/angular6-json-schema-form/src/lib/json-schema-form.service.ts
+++ b/projects/angular6-json-schema-form/src/lib/json-schema-form.service.ts
@@ -81,6 +81,7 @@ export class JsonSchemaFormService {
 
   // Default global form options
   defaultFormOptions: any = {
+    autocomplete: true, // Allow the web browser to remember previous form submission values as defaults
     addSubmit: 'auto', // Add a submit button if layout does not have one?
     // for addSubmit: true = always, false = never,
     // 'auto' = only if layout is undefined (form is built from schema alone)


### PR DESCRIPTION
Add an autocomplete attribute to the form element.  The formOptions default is configured true (i.e. 'on') for backward compatibility.

My project requires autocomplete="off" so the user will not see previous form values.  There is no CSS way to configure autocomplete="off".