### PR TITLE
Fix checkboxes input id

### DIFF
--- a/projects/angular6-json-schema-form/src/lib/widget-library/checkboxes.component.ts
+++ b/projects/angular6-json-schema-form/src/lib/widget-library/checkboxes.component.ts
@@ -47,7 +47,7 @@ import { JsonSchemaFormService, TitleMapItem } from '../json-schema-form.service
             [checked]="checkboxItem.checked"
             [class]="options?.fieldHtmlClass || ''"
             [disabled]="controlDisabled"
-            [id]="options?.name + '/' + checkboxItem.value"
+            [id]="'control' + layoutNode?._id + '/' + checkboxItem.value"
             [name]="checkboxItem?.name"
             [readonly]="options?.readonly ? 'readonly' : null"
             [value]="checkboxItem.value"


### PR DESCRIPTION
Regular checkboxes labels are not clickable because of wrong input id.
This modif should fix it.